### PR TITLE
Feat/sale flow FIFO based sale flow

### DIFF
--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/calculator/SaleCalculator.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/calculator/SaleCalculator.java
@@ -7,15 +7,28 @@ import java.math.RoundingMode;
 import java.util.Objects;
 
 public class SaleCalculator implements TransactionCalculator {
-  private final BigDecimal purchasePrice;
+  private final BigDecimal totalPurchaseCost;
   private final BigDecimal salesPrice;
   private final BigDecimal quantity;
 
   public SaleCalculator(Share share) {
+    this(Objects.requireNonNull(share, "'share' cannot be null"),
+            share.getPurchasePrice().multiply(share.getQuantity())
+    );
+  }
+
+  public SaleCalculator(Share share, BigDecimal totalPurchaseCost) {
     Objects.requireNonNull(share, "'share' cannot be null");
-    this.purchasePrice = share.getPurchasePrice();
-    this.salesPrice    = share.getStock().getSalesPrice();
-    this.quantity      = share.getQuantity();
+    Objects.requireNonNull(totalPurchaseCost, "'totalPurchaseCost' cannot be null");
+
+    if (totalPurchaseCost.compareTo(BigDecimal.ZERO) < 0) {
+      throw new IllegalArgumentException("totalPurchasePrice cannot be negative");
+    }
+
+    this.totalPurchaseCost = totalPurchaseCost;
+    this.salesPrice = share.getStock().getSalesPrice();
+    this.quantity = share.getQuantity();
+
   }
 
   @Override
@@ -34,7 +47,7 @@ public class SaleCalculator implements TransactionCalculator {
   @Override
   public BigDecimal calculateTax() {
     BigDecimal taxRate = new BigDecimal("0.30");
-    BigDecimal gain = calculateGross().subtract(calculateCommission()).subtract(purchasePrice.multiply(quantity));
+    BigDecimal gain = calculateGross().subtract(calculateCommission()).subtract(totalPurchaseCost);
 
     return taxRate.multiply(gain);
   }

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/exchange/Exchange.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/exchange/Exchange.java
@@ -2,6 +2,7 @@ package org.edu.ntnu.idatt2003.group49.millions.model.exchange;
 
 import org.edu.ntnu.idatt2003.group49.millions.model.StockSubject;
 import org.edu.ntnu.idatt2003.group49.millions.model.player.Player;
+import org.edu.ntnu.idatt2003.group49.millions.model.transaction.SaleAllocation;
 import org.edu.ntnu.idatt2003.group49.millions.model.transaction.Transaction;
 import org.edu.ntnu.idatt2003.group49.millions.model.transaction.TransactionFactory;
 
@@ -101,6 +102,26 @@ public class Exchange extends StockSubject {
     }
 
     Transaction sale = transactionFactory.createSale(ownedShare, quantityToSell, getWeek());
+    sale.commit(player);
+    return sale;
+  }
+
+  public Transaction sell(String symbol, BigDecimal quantityToSell, Player player) {
+    Objects.requireNonNull(symbol, "symbol cannot be null");
+    Objects.requireNonNull(quantityToSell, "quantityToSell cannot be null");
+    Objects.requireNonNull(player, "player cannot be null");
+
+    if (!hasStock(symbol)) {
+      throw new IllegalArgumentException("Cannot sell a share that does not exist");
+    }
+
+    if (quantityToSell.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new IllegalArgumentException("quantityToSell must be greater than zero");
+    }
+
+    List<SaleAllocation> allocations = player.getPortfolio().planSale(symbol, quantityToSell);
+
+    Transaction sale = transactionFactory.createAggregatedSale(allocations, quantityToSell, getWeek());
     sale.commit(player);
     return sale;
   }

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/player/Player.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/player/Player.java
@@ -81,7 +81,7 @@ public class Player {
   }
 
   public BigDecimal getNetWorth() {
-    return money.add(portfolio.getNetWorth());
+    return money.add(portfolio.getValue());
   }
 }
 

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/player/Portfolio.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/player/Portfolio.java
@@ -2,6 +2,7 @@ package org.edu.ntnu.idatt2003.group49.millions.model.player;
 
 import org.edu.ntnu.idatt2003.group49.millions.model.exchange.Share;
 import org.edu.ntnu.idatt2003.group49.millions.model.calculator.SaleCalculator;
+import org.edu.ntnu.idatt2003.group49.millions.model.transaction.SaleAllocation;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -44,7 +45,7 @@ public class Portfolio {
     );
   }
 
-  public BigDecimal getNetWorth() {
+  public BigDecimal getValue() {
     return shares.stream()
             .map(share -> new SaleCalculator(share).calculateGross())
             .reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -82,7 +83,51 @@ public class Portfolio {
     );
 
     shares.set(shareIndex, remainingShare);
+  }
 
+  public List<SaleAllocation> planSale(String symbol, BigDecimal quantityToSell) {
+    Objects.requireNonNull(symbol, "symbol cannot be null");
+    Objects.requireNonNull(quantityToSell, "quantityToSell cannot be null");
 
+    if (quantityToSell.compareTo(BigDecimal.ZERO) <= 0){
+      throw new IllegalArgumentException("quantityToSell must be greater than zero");
+    }
+
+    BigDecimal quantity = quantityToSell;
+    List<SaleAllocation> allocations = new ArrayList<>();
+
+    for (Share share: getShares(symbol)) {
+      BigDecimal quantityFromThisShare = share.getQuantity().min(quantity);
+
+      SaleAllocation allocation = new SaleAllocation(share, quantityFromThisShare);
+      allocations.add(allocation);
+
+      quantity = quantity.subtract(quantityFromThisShare);
+
+      if (quantity.compareTo(BigDecimal.ZERO) == 0) {
+        return allocations;
+      }
+    }
+    throw new IllegalArgumentException("Cannot sell more shares than owned");
+  }
+
+  public void applySale(List<SaleAllocation> allocations) {
+    Objects.requireNonNull(allocations, "allocations cannot be null");
+
+    if (allocations.isEmpty()) {
+      throw new IllegalArgumentException("List cannot be empty");
+    }
+
+    for (SaleAllocation allocation : allocations) {
+      Objects.requireNonNull(allocation, "allocation cannot be null");
+
+      if (!contains(allocation.getShare())) {
+        throw new IllegalArgumentException("Cannot sell a share that is not owned");
+      }
+    }
+
+    for (SaleAllocation allocation : allocations) {
+      reduceShare(allocation.getShare(), allocation.getQuantity());
+    }
   }
 }

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/player/Portfolio.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/player/Portfolio.java
@@ -49,4 +49,40 @@ public class Portfolio {
             .map(share -> new SaleCalculator(share).calculateGross())
             .reduce(BigDecimal.ZERO, BigDecimal::add);
   }
+
+  public void reduceShare(Share share, BigDecimal quantityToSell) {
+    Objects.requireNonNull(share, "share cnnot be null");
+    Objects.requireNonNull(quantityToSell, "quantityToSell cannot be null");
+
+    if (quantityToSell.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new IllegalArgumentException("quantityToSell must be greater than zero");
+    }
+
+    int shareIndex = shares.indexOf(share);
+
+    if (shareIndex == -1) {
+      throw new IllegalStateException("Cannot reduce a share that is not owned");
+    }
+
+    if (quantityToSell.compareTo(share.getQuantity()) > 0) {
+      throw new IllegalArgumentException("Cannot sell more shares than owned");
+    }
+
+    BigDecimal remainingQuantity = share.getQuantity().subtract(quantityToSell);
+
+    if (remainingQuantity.compareTo(BigDecimal.ZERO) == 0) {
+      shares.remove(shareIndex);
+      return;
+    }
+
+    Share remainingShare = new Share(
+            share.getStock(),
+            remainingQuantity,
+            share.getPurchasePrice()
+    );
+
+    shares.set(shareIndex, remainingShare);
+
+
+  }
 }

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/Sale.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/Sale.java
@@ -5,13 +5,27 @@ import org.edu.ntnu.idatt2003.group49.millions.model.calculator.TransactionCalcu
 import org.edu.ntnu.idatt2003.group49.millions.model.player.Player;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Objects;
 
 public class Sale extends Transaction {
+
+  private final List<SaleAllocation> allocations;
+
   public Sale(Share share, int week, TransactionCalculator calculator) {
-    super(share, week, calculator);
+    this(share, week, calculator, List.of(new SaleAllocation(share, share.getQuantity())));
   }
 
+  public Sale(Share share, int week, TransactionCalculator calculator, List<SaleAllocation> allocations) {
+    super(share, week, calculator);
+
+    Objects.requireNonNull(allocations, "allocations cannot be null");
+    if (allocations.isEmpty()) {
+      throw new IllegalArgumentException("allocations cannot be empty");
+    }
+
+    this.allocations = List.copyOf(allocations);
+  }
   @Override
   public void commit(Player player) {
     Objects.requireNonNull(player, "player cannot be null");
@@ -22,8 +36,8 @@ public class Sale extends Transaction {
 
     BigDecimal totalCost = getCalculator().calculateTotal();
 
+    player.getPortfolio().applySale(allocations);
     player.addMoney(totalCost);
-    player.getPortfolio().removeShare(getShare());
     player.getTransactionArchive().add(this);
     commited = true;
   }

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/SaleAllocation.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/SaleAllocation.java
@@ -1,0 +1,33 @@
+package org.edu.ntnu.idatt2003.group49.millions.model.transaction;
+
+import org.edu.ntnu.idatt2003.group49.millions.model.exchange.Share;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public class SaleAllocation {
+
+  private final Share share;
+  private final BigDecimal quantity;
+
+  public SaleAllocation(Share share, BigDecimal quantity) {
+    this.share = Objects.requireNonNull(share, "share cannot be null");
+    this.quantity = Objects.requireNonNull(quantity, "quantity cannot be null");
+
+    if (quantity.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new IllegalArgumentException("quantity must be greater than zero");
+    }
+
+    if (quantity.compareTo(share.getQuantity()) > 0) {
+      throw new IllegalArgumentException("quantity cannot be greater than share quantity");
+    }
+  }
+
+  public Share getShare() {
+    return share;
+  }
+
+  public BigDecimal getQuantity() {
+    return quantity;
+  }
+}

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/TransactionFactory.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/TransactionFactory.java
@@ -7,6 +7,7 @@ import org.edu.ntnu.idatt2003.group49.millions.model.calculator.SaleCalculator;
 import org.edu.ntnu.idatt2003.group49.millions.model.calculator.TransactionCalculator;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Objects;
 
@@ -59,8 +60,8 @@ public class TransactionFactory {
    *                                  greater than the owned quantity, or if week is negative
    */
   public Transaction createSale(Share ownedShare, BigDecimal quantityToSell, int week) {
-    Objects.requireNonNull(ownedShare, "ownedShare cannot be null");
-    Objects.requireNonNull(quantityToSell, "quantityToSell cannot be null");
+    Objects.requireNonNull(ownedShare, "'ownedShare' cannot be null");
+    Objects.requireNonNull(quantityToSell, "'quantityToSell' cannot be null");
 
     if (quantityToSell.compareTo(BigDecimal.ZERO) <= 0) {
       throw new IllegalArgumentException("quantity must be greater than zero");
@@ -75,5 +76,32 @@ public class TransactionFactory {
     SaleAllocation allocation = new SaleAllocation(ownedShare, quantityToSell);
 
     return new Sale(shareToSell, week, calculator, List.of(allocation));
+  }
+
+  public Transaction createAggregatedSale(List<SaleAllocation> allocations, BigDecimal quantityToSell, int week) {
+    Objects.requireNonNull(allocations, "'allocations' cannot be null");
+    Objects.requireNonNull(quantityToSell, "'quantityToSell' cannot be null");
+
+    if (allocations.isEmpty()) {
+      throw new IllegalArgumentException("'allocations' cannot be empty");
+    }
+
+    if (quantityToSell.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new IllegalArgumentException("quantity must be greater than zero");
+    }
+
+    Stock stock = allocations.getFirst().getShare().getStock();
+
+    BigDecimal totalPurchaseCost = allocations.stream()
+            .map(allocation -> allocation.getShare().getPurchasePrice()
+                    .multiply(allocation.getQuantity()))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    BigDecimal purchasePrice = totalPurchaseCost.divide(quantityToSell, 2, RoundingMode.HALF_UP);
+    Share aggregatedShare = new Share(stock, quantityToSell, purchasePrice);
+
+    TransactionCalculator calculator = new SaleCalculator(aggregatedShare, totalPurchaseCost);
+
+    return new Sale(aggregatedShare, week, calculator, allocations);
   }
 }

--- a/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/TransactionFactory.java
+++ b/src/main/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/TransactionFactory.java
@@ -7,6 +7,7 @@ import org.edu.ntnu.idatt2003.group49.millions.model.calculator.SaleCalculator;
 import org.edu.ntnu.idatt2003.group49.millions.model.calculator.TransactionCalculator;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -71,6 +72,8 @@ public class TransactionFactory {
     Share shareToSell = new Share(ownedShare.getStock(), quantityToSell, ownedShare.getPurchasePrice());
     TransactionCalculator calculator = new SaleCalculator(shareToSell);
 
-    return new Sale(shareToSell, week, calculator);
+    SaleAllocation allocation = new SaleAllocation(ownedShare, quantityToSell);
+
+    return new Sale(shareToSell, week, calculator, List.of(allocation));
   }
 }

--- a/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/calculator/SaleCalculatorTest.java
+++ b/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/calculator/SaleCalculatorTest.java
@@ -97,4 +97,21 @@ class SaleCalculatorTest {
     // Assert
     assertEquals(0, total.compareTo(expectedTotal));
   }
+
+  @Test
+  void calculateTax_UsesTotalPurchaseCostWhenProvided() {
+    Share aggregatedSaleShare = new Share(stock, new BigDecimal("15"), new BigDecimal("100"));
+
+    BigDecimal totalPurchaseCost = new BigDecimal("2000");
+    TransactionCalculator calculator = new SaleCalculator(aggregatedSaleShare, totalPurchaseCost);
+
+    BigDecimal expectedGross = stock.getSalesPrice().multiply(new BigDecimal("15"));
+    BigDecimal expectedCommission = expectedGross.multiply(new BigDecimal("0.01")).setScale(2, RoundingMode.HALF_UP);
+
+    BigDecimal expectedGain = expectedGross.subtract(expectedCommission).subtract(totalPurchaseCost);
+
+    BigDecimal expectedTax = new BigDecimal("0.30").multiply(expectedGain);
+
+    assertEquals(0, expectedTax.compareTo(calculator.calculateTax()));
+  }
 }

--- a/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/exchange/ExchangeTest.java
+++ b/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/exchange/ExchangeTest.java
@@ -6,7 +6,6 @@ import org.edu.ntnu.idatt2003.group49.millions.model.transaction.TransactionFact
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -153,7 +152,7 @@ class ExchangeTest {
   @Test
   void sell_ThrowsWhenShareIsNull() {
     assertThrows(NullPointerException.class,
-            () -> exchange.sell(null, new BigDecimal("1"), new Player("Steve", new BigDecimal("1000"))));
+            () -> exchange.sell((Share) null, new BigDecimal("1"), new Player("Steve", new BigDecimal("1000"))));
   }
 
   @Test
@@ -214,6 +213,32 @@ class ExchangeTest {
     assertThrows(IllegalArgumentException.class,
             () -> exchange.sell(share, new BigDecimal("2"), player));
   }
+  @Test
+  void sell_WithSymbol_SellsFromTotalHoldingUsingFifo() {
+    Player player = new Player("Steve", new BigDecimal("1000"));
+
+    Share firstShare = new Share(nvidiaStock, BigDecimal.TEN, new BigDecimal("100"));
+    Share secondShare = new Share(nvidiaStock, BigDecimal.TEN, new BigDecimal("200"));
+
+    player.getPortfolio().addShare(firstShare);
+    player.getPortfolio().addShare(secondShare);
+
+    Transaction sale = exchange.sell("NVDA", new BigDecimal("15"), player);
+
+    assertTrue(sale.isCommited());
+
+    List<Share> remainingShares = player.getPortfolio().getShares("NVDA");
+
+    //tester at det bare er et share objekt av nvidia igjen
+    assertEquals(1, remainingShares.size());
+
+    // tester at FIFO fjernet første NVDA-lot og bare rest-lot står igjen
+    assertEquals(0, new BigDecimal("5").compareTo(remainingShares.getFirst().getQuantity()));
+
+    //tester at kjøpsprisen på de resterende sharesene er 200 per
+    assertEquals(0, new BigDecimal("200").compareTo(remainingShares.getFirst().getPurchasePrice()));
+  }
+
 
   @Test
   void advance_IncrementsWeekByOne() {

--- a/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/player/PortfolioTest.java
+++ b/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/player/PortfolioTest.java
@@ -2,6 +2,7 @@ package org.edu.ntnu.idatt2003.group49.millions.model.player;
 
 import org.edu.ntnu.idatt2003.group49.millions.model.exchange.Share;
 import org.edu.ntnu.idatt2003.group49.millions.model.exchange.Stock;
+import org.edu.ntnu.idatt2003.group49.millions.model.transaction.SaleAllocation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -105,6 +106,84 @@ class PortfolioTest {
     assertEquals(0, new BigDecimal("30").compareTo(remainingShare.getQuantity()));
     assertEquals(share.getStock(),remainingShare.getStock());
   }
+
+  @Test
+  void planSale_ReturnsMultipleAllocationsWhenQuantityExceedsFirstShare() {
+    Stock stock = new Stock("NVDA", "Nvidia", new BigDecimal("100"));
+
+    Share firstShare = new Share(stock, BigDecimal.TEN, new BigDecimal("100"));
+    Share secondShare = new Share(stock, BigDecimal.TEN, new BigDecimal("150"));
+
+    portfolio.addShare(firstShare);
+    portfolio.addShare(secondShare);
+
+    List<SaleAllocation> allocations = portfolio.planSale(stock.getSymbol(), new BigDecimal("15"));
+
+    assertEquals(2, allocations.size());
+
+    assertEquals(firstShare, allocations.get(0).getShare());
+    assertEquals(0, BigDecimal.TEN.compareTo(allocations.get(0).getQuantity()));
+
+    assertEquals(secondShare, allocations.get(1).getShare());
+    assertEquals(0, new BigDecimal("5").compareTo(allocations.get(1).getQuantity()));
+  }
+
+  @Test
+  void planSale_ThrowsWhenQuantityExceedsTotalOwnedShares() {
+    Stock stock = new Stock("NVDA", "Nvidia", new BigDecimal("100"));
+
+    Share firstShare = new Share(stock, BigDecimal.TEN, new BigDecimal("100"));
+    Share secondShare = new Share(stock, BigDecimal.TEN, new BigDecimal("150"));
+
+    portfolio.addShare(firstShare);
+    portfolio.addShare(secondShare);
+
+    assertThrows(IllegalArgumentException.class,
+            () -> portfolio.planSale(stock.getSymbol(), new BigDecimal("30")));
+  }
+
+  @Test
+  void planSale_DoesNotChangePortfolioWhenQuantityExceedsTotalOwnedShares() {
+    Stock stock = new Stock("NVDA", "Nvidia", new BigDecimal("100"));
+
+    Share firstShare = new Share(stock, BigDecimal.TEN, new BigDecimal("100"));
+    Share secondShare = new Share(stock, BigDecimal.TEN, new BigDecimal("150"));
+
+    portfolio.addShare(firstShare);
+    portfolio.addShare(secondShare);
+
+    assertThrows(IllegalArgumentException.class,
+            () -> portfolio.planSale(stock.getSymbol(), new BigDecimal("30")));
+
+    assertTrue(portfolio.contains(firstShare));
+    assertTrue(portfolio.contains(secondShare));
+    assertEquals(0, BigDecimal.TEN.compareTo(firstShare.getQuantity()));
+    assertEquals(0, BigDecimal.TEN.compareTo(secondShare.getQuantity()));
+  }
+
+  @Test
+  void applySale_RemovesFirstShareAndReducesSecondShare() {
+    Stock stock = new Stock("NVDA", "Nvidia", new BigDecimal("100"));
+
+    Share firstShare = new Share(stock, BigDecimal.TEN, new BigDecimal("100"));
+    Share secondShare = new Share(stock, BigDecimal.TEN, new BigDecimal("150"));
+
+    portfolio.addShare(firstShare);
+    portfolio.addShare(secondShare);
+
+    List<SaleAllocation> allocations =
+            portfolio.planSale(stock.getSymbol(), new BigDecimal("15"));
+
+    portfolio.applySale(allocations);
+
+    List<Share> remainingShares = portfolio.getShares(stock.getSymbol());
+
+    assertEquals(1, remainingShares.size());
+    assertEquals(0, new BigDecimal("5").compareTo(remainingShares.getFirst().getQuantity()));
+    assertEquals(0, new BigDecimal("150").compareTo(remainingShares.getFirst().getPurchasePrice()));
+  }
+
+
 }
 
 

--- a/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/player/PortfolioTest.java
+++ b/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/player/PortfolioTest.java
@@ -81,5 +81,31 @@ class PortfolioTest {
   void contains_ThrowsWhenShareIsNull() {
     assertThrows(NullPointerException.class, () -> {portfolio.contains(null);});
   }
+
+
+  @Test
+  void reduceShare_ThrowsWhenSellingMoreThanOwned() {
+    assertThrows(IllegalArgumentException.class,
+            () -> portfolio.reduceShare(share, new BigDecimal("51")));
+  }
+
+  @Test
+  void reduceShare_RemovesShareWhenSellingAllShares() {
+    portfolio.reduceShare(share, new BigDecimal("50"));
+
+    assertFalse(portfolio.contains(share));
+  }
+
+  @Test
+  void reduceShare_ReplacesShareWithRemainingQuantityAfterPartialSale() {
+    portfolio.reduceShare(share, new BigDecimal("20"));
+
+    Share remainingShare = portfolio.getShares().getFirst();
+
+    assertEquals(0, new BigDecimal("30").compareTo(remainingShare.getQuantity()));
+    assertEquals(share.getStock(),remainingShare.getStock());
+  }
 }
+
+
 

--- a/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/SaleTest.java
+++ b/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/SaleTest.java
@@ -1,11 +1,10 @@
-package org.edu.ntnu.idatt2003.group49.millions.transaction;
+package org.edu.ntnu.idatt2003.group49.millions.model.transaction;
 
 import org.edu.ntnu.idatt2003.group49.millions.model.player.Player;
 import org.edu.ntnu.idatt2003.group49.millions.model.exchange.Share;
 import org.edu.ntnu.idatt2003.group49.millions.model.exchange.Stock;
 import org.edu.ntnu.idatt2003.group49.millions.model.calculator.SaleCalculator;
 import org.edu.ntnu.idatt2003.group49.millions.model.calculator.TransactionCalculator;
-import org.edu.ntnu.idatt2003.group49.millions.model.transaction.Sale;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +58,8 @@ class SaleTest {
 
   @Test
   void commit_ThrowsWhenTransactionIsAlreadyCommited() {
+    player.getPortfolio().addShare(share);
+
     sale.commit(player);
 
     assertThrows(IllegalArgumentException.class, () -> sale.commit(player));
@@ -66,13 +67,14 @@ class SaleTest {
 
   @Test
   void commit_ThrowsWhenPlayerDoesNotOwnShare() {
-    sale.commit(player);
+    Player playerWithoutShare = new Player("Steve", new BigDecimal("100"));
 
-    assertThrows(IllegalArgumentException.class, () -> sale.commit(player));
+    assertThrows(IllegalArgumentException.class, () -> sale.commit(playerWithoutShare));
   }
 
   @Test
   void commit_AddsSalesRevenueToPlayersMoney() {
+    player.getPortfolio().addShare(share);
     BigDecimal prevPlayerMoney = player.getMoney();
     sale.commit(player);
 
@@ -83,6 +85,8 @@ class SaleTest {
 
   @Test
   void commit_RemovesShareFromPlayerPortfolio() {
+    player.getPortfolio().addShare(share);
+
     sale.commit(player);
 
     assertFalse(player.getPortfolio().contains(share));

--- a/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/TransactionFactoryTest.java
+++ b/src/test/java/org/edu/ntnu/idatt2003/group49/millions/model/transaction/TransactionFactoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -115,4 +116,20 @@ class TransactionFactoryTest {
     );
   }
 
+  @Test
+  void createAggregatedSale_ReturnsOneSaleFromDifferentAllocations() {
+    Share firstShare = new Share(nvidiaStock, BigDecimal.TEN, new BigDecimal("100"));
+    Share secondShare = new Share(nvidiaStock, BigDecimal.TEN, new BigDecimal("200"));
+
+    SaleAllocation firstAllocation = new SaleAllocation(firstShare, BigDecimal.TEN);
+    SaleAllocation secondAllocation = new SaleAllocation(secondShare, BigDecimal.TEN);
+
+    List<SaleAllocation> allocations = List.of(firstAllocation, secondAllocation);
+    Transaction transaction = transactionFactory.createAggregatedSale(allocations, new BigDecimal("20"), 1);
+
+    assertInstanceOf(Sale.class, transaction);
+    assertEquals(nvidiaStock, transaction.getShare().getStock());
+    assertEquals(0, new BigDecimal("20").compareTo(transaction.getShare().getQuantity()));
+    assertEquals(0, new BigDecimal("150").compareTo(transaction.getShare().getPurchasePrice()));
+  }
 }


### PR DESCRIPTION
implemented partial sale and FIFO based sale flow

- Added partial sale handling for owned Share lots
- Added FIFO sale planning and portfolio reduction with SaleAllocation
- Added aggregated Sale creation for symbol-based sales


A sale now reduces different share lots while creating one sale transaction. lots keep their puchase price and the first bought will be the first sold(FIFO).

Tax is calculated correctly when different purchase prices are used for selling

added main function tests for the new methods regarding FIFO sales